### PR TITLE
bug fix for removeSigner functionality

### DIFF
--- a/packages/hardhat/contracts/MultiSigWallet.sol
+++ b/packages/hardhat/contracts/MultiSigWallet.sol
@@ -88,7 +88,7 @@ contract MultiSigWallet {
         owners.pop();
       } else {
         owners.pop();
-        for (uint256 j = i; j < ownersLength - 1; j++) {
+        for (uint256 j = i+1; j <= ownersLength - 1; j++) {
           owners.push(poppedOwners[j]);
         }
         return;


### PR DESCRIPTION
The logic in _removeOwner() needs a correction,

```
        owners.pop();
        for (uint256 j = i; j < ownersLength - 1; j++) {
          owners.push(poppedOwners[j]);
        }
```
If the above loop starts from i, then a zero address will be pushed into owners array.
The fix is to start the loop from i+1 and end at (ownersLength - 1)th index.
